### PR TITLE
Remove the redundant text describing TX behavior.

### DIFF
--- a/draft-ietf-idr-rfc4360-bis.xml
+++ b/draft-ietf-idr-rfc4360-bis.xml
@@ -403,8 +403,6 @@
         Non-transitive extended communities MUST NOT be sent (originated or propagated) across an Autonomous System boundary unless
         explicitly configured to do so. Non-transitive extended communities SHOULD NOT be removed when advertising the route within the
         same BGP AS Confederation (as defined in <xref target="RFC5065"/>).
-        As part of configuration or explicitly stated by the BGP protocol extensions, BGP speakers MAY propagate non-transitive extended
-        communities across Autonomous System boundaries.
       </t>
       <t>
         By default, when a BGP speaker receives routes with non-transitive extended communities across Autonomous System or Confederation 
@@ -914,7 +912,7 @@
       </t>
       <t>
         We also thank Jeffrey Haas, Robert Raszuk, Bruno Decraene, Linda Dunbar, Yingzhen Qu, Jie Dong, Lizhen Qiang, Erik Auerswald, Aijun
-        Wang and John Scudder for their suggestions and feedback on this document.
+        Wang, and John Scudder for their suggestions and feedback on this document.
       </t>
     </section>
   </middle>


### PR DESCRIPTION
Remove the redundant text in the operations section:
"As part of configuration or explicitly stated by the BGP protocol extensions, BGP speakers MAY propagate non-transitive extended communities across Autonomous System boundaries."