### PR TITLE
Update the IANA Considerations section:

### DIFF
--- a/draft-ietf-idr-rfc4360-bis.xml
+++ b/draft-ietf-idr-rfc4360-bis.xml
@@ -427,152 +427,168 @@
 
     <section title="IANA Considerations" anchor="iana-considerations">
       <t>
-        Since this document obsoletes <xref target="RFC4360"/>, IANA is requested to replace all references to <xref target="RFC4360"/>
-        with [this document] in the "BGP Path Attributes" <xref target="IANA-BGP-PATH-ATTRIBUTES"/> registry,
-        the "BGP Extended Communities" <xref target="IANA-BGP-EC"/> registry group, and the "IPFIX Entities" <xref target="IANA-IPFIX"/>
-        registry group.
+        This document obsoletes <xref target="RFC4360"/>, but it does not change the IANA Considerations of <xref target="RFC7153"/>
+        that updated <xref target="RFC4360"/> and created the "Border Gateway Protocol (BGP) Extended Communities" <xref target="IANA-BGP-EC"/>
+        registry group along with the registries therein corresponding to the specifications in this document.
+        Therefore, IANA should continue to manage those registries as per <xref target="RFC7153"/>.
       </t>
-      <section title="Registries for the Type Field">
-        <section title="BGP Transitive Extended Community Types">
-          <t>
-            The IANA is requested to update the following references in the "BGP Transitive Extended Community Types" registry
-            <xref target="IANA-BGP-EC-TRANS"/> :
-          </t>
-          <table>
-            <name>BGP Transitive Extended Community Types</name>
-            <thead>
-              <tr>
-                <th>TYPE VALUE</th>
-                <th>NAME</th>
-                <th>REFERENCE</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td align="left">0x00</td>
-                <td align="left">
-                  Transitive Two-Octet AS-Specific Extended Community (Sub-Types are defined in the "Transitive Two-Octet AS-Specific
-                  Extended Community Sub-Types" registry <xref target="IANA-BGP-EC-TRANS-TWO-OCTET-AS"/>)
-                </td>
-                <td align="left">
-                  <xref target="RFC7153"/>
-                  [this document]
-                </td>
-              </tr>
-              <tr>
-                <td align="left">0x01</td>
-                <td align="left">
-                  Transitive IPv4-Address-Specific Extended Community (Sub-Types are defined in the "Transitive IPv4-Address-Specific
-                  Extended Community Sub-Types" registry <xref target="IANA-BGP-EC-TRANS-IPV4"/>)
-                </td>
-                <td align="left">
-                  <xref target="RFC7153"/>
-                  [this document]
-                </td>
-              </tr>
-              <tr>
-                <td align="left">0x03</td>
-                <td align="left">
-                  Transitive Opaque Extended Community (Sub-Types are defined in the "Transitive Opaque Extended Community Sub-Types"
-                  registry <xref target="IANA-BGP-EC-TRANS-OPAQUE"/>)
-                </td>
-                <td align="left">
-                  <xref target="RFC7153"/>
-                  [this document]
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </section>
-        <section title="BGP Non-Transitive Extended Community Types">
-          <t>
-            The IANA is requested to update the following references in the "BGP Non-Transitive Extended Community Types" registry
-            <xref target="IANA-BGP-EC-NONTRANS"/>:
-          </t>
-          <table>
-            <name>BGP Non-Transitive Extended Community Types</name>
-            <thead>
-              <tr>
-                <th>TYPE VALUE</th>
-                <th>NAME</th>
-                <th>REFERENCE</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td align="left">0x40</td>
-                <td align="left">
-                  Non-Transitive Two-Octet AS-Specific Extended Community (Sub-Types are defined in the "Non-Transitive Two-Octet
-                  AS-Specific Extended Community Sub-Types" registry <xref target="IANA-BGP-EC-NONTRANS-TWO-OCTET-AS"/>)
-                </td>
-                <td align="left">
-                  <xref target="RFC7153"/>
-                  [this document]
-                </td>
-              </tr>
-              <tr>
-                <td align="left">0x41</td>
-                <td align="left">
-                  Non-Transitive IPv4-Address-Specific Extended Community (Sub-Types are defined in the "Non-Transitive
-                  IPv4-Address-Specific Extended Community Sub-Types" registry <xref target="IANA-BGP-EC-NONTRANS-IPV4"/>)
-                </td>
-                <td align="left">
-                  <xref target="RFC7153"/>
-                  [this document]
-                </td>
-              </tr>
-              <tr>
-                <td align="left">0x43</td>
-                <td align="left">
-                  Non-Transitive Opaque Extended Community (Sub-Types are defined in the "Non-Transitive Opaque Extended Community
-                  Sub-Types" registry <xref target="IANA-BGP-EC-NONTRANS-OPAQUE"/>)
-                </td>
-                <td align="left">
-                  <xref target="RFC7153"/>
-                  [this document]
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </section>
-      </section>
-
-      <section title="Registries for the Sub-Type Field">
-        <section title="Four-Octet AS-Specific Extended Community Sub-Types">
-          <t>
-            The IANA is requested to update the following references in the "Transitive Four-Octet AS-Specific Extended Community
-            Sub-Types" registry <xref target="IANA-BGP-EC-TRANS-FOUR-OCTET-AS"/>:
-          </t>
-          <table>
-            <name>Transitive Four-Octet AS-Specific Extended Community Sub-Types</name>
-            <thead>
-              <tr>
-                <th>SUB-TYPE VALUE</th>
-                <th>NAME</th>
-                <th>REFERENCE</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td align="left">0x02</td>
-                <td align="left">Route Target</td>
-                  <td align="left">
-                    <xref target="RFC5668"/>
-                    [this document]
-                  </td>
-              </tr>
-              <tr>
-                <td align="left">0x03</td>
-                <td align="left">Route Origin</td>
-                  <td align="left">
-                    <xref target="RFC5668"/>
-                    [this document]
-                  </td>
-              </tr>
-            </tbody>
-          </table>
-        </section>
-      </section>
+      <t>
+        However, IANA is requested to replace all references to <xref target="RFC4360"/> with this document in the "BGP Path Attributes"
+        <xref target="IANA-BGP-PATH-ATTRIBUTES"/> registry, the "BGP Extended Communities" <xref target="IANA-BGP-EC"/> registry group,
+        and the "IPFIX Entities" <xref target="IANA-IPFIX"/> registry group.
+      </t>
+      <t>
+        IANA is requested to list this document as an additional reference for the following entries in the "BGP Transitive Extended
+        Community Types" registry <xref target="IANA-BGP-EC-TRANS"/>:
+      </t>
+      <table>
+        <name>BGP Transitive Extended Community Types</name>
+        <thead>
+          <tr>
+            <th>TYPE VALUE</th>
+            <th>NAME</th>
+            <th>REFERENCE</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td align="left">0x00</td>
+            <td align="left">
+              Transitive Two-Octet AS-Specific Extended Community (Sub-Types are defined in the "Transitive Two-Octet AS-Specific
+              Extended Community Sub-Types" registry <xref target="IANA-BGP-EC-TRANS-TWO-OCTET-AS"/>)
+            </td>
+            <td align="left">
+              <xref target="RFC7153"/>
+              [this document]
+            </td>
+          </tr>
+          <tr>
+            <td align="left">0x01</td>
+            <td align="left">
+              Transitive IPv4-Address-Specific Extended Community (Sub-Types are defined in the "Transitive IPv4-Address-Specific
+              Extended Community Sub-Types" registry <xref target="IANA-BGP-EC-TRANS-IPV4"/>)
+            </td>
+            <td align="left">
+              <xref target="RFC7153"/>
+              [this document]
+            </td>
+          </tr>
+          <tr>
+            <td align="left">0x03</td>
+            <td align="left">
+              Transitive Opaque Extended Community (Sub-Types are defined in the "Transitive Opaque Extended Community Sub-Types"
+              registry <xref target="IANA-BGP-EC-TRANS-OPAQUE"/>)
+            </td>
+            <td align="left">
+              <xref target="RFC7153"/>
+              [this document]
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <t>
+        IANA is requested to list this document as an additional reference for the following entries in the "BGP Non-Transitive Extended
+        Community Types" registry <xref target="IANA-BGP-EC-NONTRANS"/> :
+      </t>
+      <table>
+        <name>BGP Non-Transitive Extended Community Types</name>
+        <thead>
+          <tr>
+            <th>TYPE VALUE</th>
+            <th>NAME</th>
+            <th>REFERENCE</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td align="left">0x40</td>
+            <td align="left">
+              Non-Transitive Two-Octet AS-Specific Extended Community (Sub-Types are defined in the "Non-Transitive Two-Octet
+              AS-Specific Extended Community Sub-Types" registry <xref target="IANA-BGP-EC-NONTRANS-TWO-OCTET-AS"/>)
+            </td>
+            <td align="left">
+              <xref target="RFC7153"/>
+              [this document]
+            </td>
+          </tr>
+          <tr>
+            <td align="left">0x41</td>
+            <td align="left">
+              Non-Transitive IPv4-Address-Specific Extended Community (Sub-Types are defined in the "Non-Transitive
+              IPv4-Address-Specific Extended Community Sub-Types" registry <xref target="IANA-BGP-EC-NONTRANS-IPV4"/>)
+            </td>
+            <td align="left">
+              <xref target="RFC7153"/>
+              [this document]
+            </td>
+          </tr>
+          <tr>
+            <td align="left">0x43</td>
+            <td align="left">
+              Non-Transitive Opaque Extended Community (Sub-Types are defined in the "Non-Transitive Opaque Extended Community
+              Sub-Types" registry <xref target="IANA-BGP-EC-NONTRANS-OPAQUE"/>)
+            </td>
+            <td align="left">
+              <xref target="RFC7153"/>
+              [this document]
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <t>
+        IANA is requested to list this document as an additional reference for the following entries in the "Transitive Four-Octet
+        AS-Specific Extended Community Sub-Types" registry <xref target="IANA-BGP-EC-TRANS-FOUR-OCTET-AS"/>:
+      </t>
+      <table>
+        <name>Transitive Four-Octet AS-Specific Extended Community Sub-Types</name>
+        <thead>
+          <tr>
+            <th>SUB-TYPE VALUE</th>
+            <th>NAME</th>
+            <th>REFERENCE</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td align="left">0x02</td>
+            <td align="left">Route Target</td>
+              <td align="left">
+                <xref target="RFC5668"/>
+                [this document]
+              </td>
+          </tr>
+          <tr>
+            <td align="left">0x03</td>
+            <td align="left">Route Origin</td>
+              <td align="left">
+                <xref target="RFC5668"/>
+                [this document]
+              </td>
+          </tr>
+        </tbody>
+      </table>
+      <t>
+        Furthermore, IANA is requested to add the note below to the following registries under the "BGP Extended Communities" registry
+        group:
+      </t>
+      <ul>
+        <li>BGP Transitive Extended Community Types <xref target="IANA-BGP-EC-TRANS"/></li>
+        <li>BGP Non-Transitive Extended Community Types <xref target="IANA-BGP-EC-NONTRANS"/></li>
+        <li>Transitive Two-Octet AS-Specific Extended Community Sub-Types <xref target="IANA-BGP-EC-TRANS-TWO-OCTET-AS"/></li>
+        <li>Non-Transitive Two-Octet AS-Specific Extended Community Sub-Types <xref target="IANA-BGP-EC-NONTRANS-TWO-OCTET-AS"/></li>
+        <li>Transitive Four-Octet AS-Specific Extended Community Sub-Types <xref target="IANA-BGP-EC-TRANS-FOUR-OCTET-AS"/></li>
+        <li>Non-Transitive Four-Octet AS-Specific Extended Community Sub-Types <xref target="IANA-BGP-EC-NONTRANS-FOUR-OCTET-AS"/></li>
+        <li>Transitive IPv4-Address-Specific Extended Community Sub-Types <xref target="IANA-BGP-EC-TRANS-IPV4"/></li>
+        <li>Non-Transitive IPv4-Address-Specific Extended Community Sub-Types <xref target="IANA-BGP-EC-NONTRANS-IPV4"/></li>
+        <li>Transitive Opaque Extended Community Sub-Types <xref target="IANA-BGP-EC-TRANS-OPAQUE"/></li>
+        <li>Non-Transitive Opaque Extended Community Sub-Types <xref target="IANA-BGP-EC-NONTRANS-OPAQUE"/></li>
+        <li>Transitive IPv6-Address-Specific Extended Community Types <xref target="IANA-BGP-EC-TRANS-IPV6"/></li>
+        <li>Non-Transitive IPv6-Address-Specific Extended Community Types <xref target="IANA-BGP-EC-NONTRANS-IPV6"/></li>
+      </ul>
+      <t>
+        "When an Extended Community requests allocation for a code point of both transitive and non-transitive variants for the same
+        type/sub-type, it is recommended that the same value be assigned to them."
+      </t>
     </section>
 
     <section title="Security Considerations" anchor="security-considerations">
@@ -741,9 +757,39 @@
           </author>
         </front>
       </reference>
+      <reference anchor="IANA-BGP-EC-NONTRANS-FOUR-OCTET-AS" target="https://www.iana.org/assignments/bgp-extended-communities/bgp-extended-communities.xhtml#non-trans-four-octet-as" derivedAnchor="IANA-BGP-EC-NONTRANS-FOUR-OCTET-AS">
+        <front>
+          <title>Non-Transitive Four-Octet AS-Specific Extended Community Sub-Types</title>
+          <author>
+            <organization showOnFrontPage="true">
+              IANA
+            </organization>
+          </author>
+        </front>
+      </reference>
       <reference anchor="IANA-IPFIX" target="https://www.iana.org/assignments/ipfix/ipfix.xhtml" derivedAnchor="IANA-IPFIX">
         <front>
           <title>IPFIX Entities</title>
+          <author>
+            <organization showOnFrontPage="true">
+              IANA
+            </organization>
+          </author>
+        </front>
+      </reference>
+      <reference anchor="IANA-BGP-EC-TRANS-IPV6" target="https://www.iana.org/assignments/bgp-extended-communities/bgp-extended-communities.xhtml#trans-ipv6" derivedAnchor="IANA-BGP-EC-TRANS-IPV6">
+        <front>
+          <title>Transitive IPv6-Address-Specific Extended Community Types</title>
+          <author>
+            <organization showOnFrontPage="true">
+              IANA
+            </organization>
+          </author>
+        </front>
+      </reference>
+      <reference anchor="IANA-BGP-EC-NONTRANS-IPV6" target="https://www.iana.org/assignments/bgp-extended-communities/bgp-extended-communities.xhtml#non-trans-ipv6" derivedAnchor="IANA-BGP-EC-NONTRANS-IPV6">
+        <front>
+          <title>Non-Transitive IPv6-Address-Specific Extended Community Types</title>
           <author>
             <organization showOnFrontPage="true">
               IANA

--- a/draft-ietf-idr-rfc4360-bis.xml
+++ b/draft-ietf-idr-rfc4360-bis.xml
@@ -433,68 +433,7 @@
         registry group.
       </t>
       <section title="Registries for the Type Field">
-        <t>
-          All the BGP Extended Communities contain a Type field.
-        </t>
-        <t>
-          The Type could be either regular or extended.
-          For a Regular Type, the IANA allocates a 1-octet type value;
-          for an Extended Type, the IANA allocates both a 1-octet type value and a 1-octet sub-type value.
-        </t>
-        <t>
-          The high-order octet values allocated for the Regular Types and for the Extended Types are mutually exclusive.
-          The value allocated for a Regular Type MUST NOT be reused as the value of the high-order octet when allocating an Extended Type.
-          The value of the high-order octet allocated for an Extended Type MUST NOT be reused when allocating a Regular Type.
-        </t>
-        <t>
-          The Type field also indicates whether the Extended Community is transitive or not.
-          Future requests for assignment of a Type value must specify whether the Type value is intended for a transitive or
-          a non-transitive Extended Community.
-        </t>
         <section title="BGP Transitive Extended Community Types">
-          <t>
-            The IANA has created a registry entitled "BGP Transitive Extended Community Types" <xref target="IANA-BGP-EC-TRANS"/>.
-            The IANA will maintain this registry. The assignments of this registry consist of the name and the value.
-          </t>
-          <t>
-            Future assignments are to be made using either the Standards Action process defined in <xref target="RFC8126"/>,
-            the Early IANA Allocation process defined in <xref target="RFC7120"/>,
-            or the "First Come First Served" policy defined in <xref target="RFC8126"/>.
-          </t>
-          <t>
-            Further definitions of sub-type registries, along with their allocation policies, can be found in <xref target="RFC7153"/>.
-          </t>
-          <t>
-            The following table summarizes the ranges for the assignment of the "BGP Transitive Extended Community Types" registry
-            <xref target="IANA-BGP-EC-TRANS"/>:
-          </t>
-          <table>
-            <name>BGP Transitive Extended Community Type Ranges</name>
-            <thead>
-              <tr>
-                <th>TYPE VALUE RANGE</th>
-                <th>REGISTRATION PROCEDURES</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td align="left">0x00-0x3F</td>
-                <td align="left">First Come First Served</td>
-              </tr>
-              <tr>
-                <td align="left">0x80-0x82</td>
-                <td align="left">First Come First Served (see <xref target="RFC9184"/>)</td>
-              </tr>
-              <tr>
-                <td align="left">0x83-0x8F</td>
-                <td align="left">Experimental Use (see <xref target="RFC3692"/>)</td>
-              </tr>
-              <tr>
-                <td align="left">0x90-0xBF</td>
-                <td align="left">Standards Action</td>
-              </tr>
-            </tbody>
-          </table>
           <t>
             The IANA is requested to update the following references in the "BGP Transitive Extended Community Types" registry
             <xref target="IANA-BGP-EC-TRANS"/> :
@@ -546,49 +485,6 @@
           </table>
         </section>
         <section title="BGP Non-Transitive Extended Community Types">
-          <t>
-            The IANA has created a registry entitled "BGP Non-Transitive Extended Community Types" <xref target="IANA-BGP-EC-NONTRANS"/>.
-            The IANA will maintain this registry. The assignments of this registry consist of the name and the value.
-          </t>
-          <t>
-            Future assignments are to be made using either the Standards Action process defined in <xref target="RFC8126"/>,
-            the Early IANA Allocation process defined in <xref target="RFC7120"/>,
-            or the "First Come First Served" policy defined in <xref target="RFC8126"/>.
-          </t>
-          <t>
-            Further definitions of sub-type registries, along with their allocation policies, can be found in <xref target="RFC7153"/>.
-          </t>
-          <t>
-            Should the conditions be met, early sub-type registry creation can be initiated and tracked using the Early Registry Creation
-            process.
-          </t>
-          <t>
-            The following table summarizes the ranges for the assignment of the "BGP Non-Transitive Extended Community Types" registry
-            <xref target="IANA-BGP-EC-NONTRANS"/>:
-          </t>
-          <table>
-            <name>BGP Non-Transitive Extended Community Type Ranges</name>
-            <thead>
-              <tr>
-                <th>TYPE VALUE RANGE</th>
-                <th>REGISTRATION PROCEDURES</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td align="left">0x40-0x7F</td>
-                <td align="left">First Come First Served</td>
-              </tr>
-              <tr>
-                <td align="left">0xC0-0xCF</td>
-                <td align="left">Experimental Use (see <xref target="RFC3692"/>)</td>
-              </tr>
-              <tr>
-                <td align="left">0xD0-0xFF</td>
-                <td align="left">Standards Action</td>
-              </tr>
-            </tbody>
-          </table>
           <t>
             The IANA is requested to update the following references in the "BGP Non-Transitive Extended Community Types" registry
             <xref target="IANA-BGP-EC-NONTRANS"/>:
@@ -642,236 +538,6 @@
       </section>
 
       <section title="Registries for the Sub-Type Field">
-        <t>
-          When requesting an allocation from more than one registry defined in this section,
-          one may ask for allocating the same Type value from these registries.
-          If possible, the IANA should accommodate such requests.
-        </t>
-        <section title="Two-Octet AS-Specific Extended Community Sub-Types">
-          <t>
-            This document defines a class of extended communities called "Two-Octet AS-Specific Extended Community" for which the IANA is to
-            create and maintain two registries entitled "Transitive Two-Octet AS-Specific Extended Community Sub-Types"
-            <xref target="IANA-BGP-EC-TRANS-TWO-OCTET-AS"/>
-            and "Non-Transitive Two-Octet AS-Specific Extended Community Sub-Types" <xref target="IANA-BGP-EC-NONTRANS-TWO-OCTET-AS"/>.
-          </t>
-          <t>
-            The following table summarizes the ranges for the assignment of the "Transitive Two-Octet AS-Specific Extended Community
-            Sub-Types" registry <xref target="IANA-BGP-EC-TRANS-TWO-OCTET-AS"/>:
-          </t>
-          <table>
-            <name>Transitive Two-Octet AS-Specific Extended Community Sub-Type Ranges</name>
-            <thead>
-              <tr>
-                <th>SUB-TYPE VALUE RANGE</th>
-                <th>REGISTRATION PROCEDURES</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td align="left">0x00-0xBF</td>
-                <td align="left">First Come First Served</td>
-              </tr>
-              <tr>
-                <td align="left">0xC0-0xFF</td>
-                <td align="left">IETF Review</td>
-              </tr>
-            </tbody>
-          </table>
-          <t>
-            The IANA is requested to update the following references in the "Transitive Two-Octet AS-Specific Extended Community
-            Sub-Types" registry <xref target="IANA-BGP-EC-TRANS-TWO-OCTET-AS"/>:
-          </t>
-          <table>
-            <name>Transitive Two-Octet AS-Specific Extended Community Sub-Types</name>
-            <thead>
-              <tr>
-                <th>SUB-TYPE VALUE</th>
-                <th>NAME</th>
-                <th>REFERENCE</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td align="left">0x02</td>
-                <td align="left">Route Target</td>
-                <td align="left">[this document]</td>
-              </tr>
-              <tr>
-                <td align="left">0x03</td>
-                <td align="left">Route Origin</td>
-                <td align="left">[this document]</td>
-              </tr>
-            </tbody>
-          </table>
-          <t>
-            The following table summarizes the ranges for the assignment of the "Non-Transitive Two-Octet AS-Specific Extended Community
-            Sub-Types" registry <xref target="IANA-BGP-EC-NONTRANS-TWO-OCTET-AS"/>:
-          </t>
-          <table>
-            <name>Non-Transitive Two-Octet AS-Specific Extended Community Sub-Type Ranges</name>
-            <thead>
-              <tr>
-                <th>SUB-TYPE VALUE RANGE</th>
-                <th>REGISTRATION PROCEDURES</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td align="left">0x00-0xBF</td>
-                <td align="left">First Come First Served</td>
-              </tr>
-              <tr>
-                <td align="left">0xC0-0xFF</td>
-                <td align="left">IETF Review</td>
-              </tr>
-            </tbody>
-          </table>
-          <t>
-            All the communities in this class are of Extended Types.
-            <xref target="RFC7153"/> includes further assignments of these registries.
-          </t>
-        </section>
-        <section title="IPv4-Address-Specific Extended Community Sub-Types">
-          <t>
-            This document defines a class of extended communities called "IPv4-Address-Specific Extended Community" for which the IANA is to
-            create and maintain two registries entitled "Transitive IPv4-Address-Specific Extended Community Sub-Types"
-            <xref target="IANA-BGP-EC-TRANS-IPV4"/>
-            and "Non-Transitive IPv4-Address-Specific Extended Community Sub-Types" <xref target="IANA-BGP-EC-NONTRANS-IPV4"/>.
-          </t>
-          <t>
-            The following table summarizes the ranges for the assignment of the "Transitive IPv4-Address-Specific Extended Community
-            Sub-Types" registry <xref target="IANA-BGP-EC-TRANS-IPV4"/>:
-          </t>
-          <table>
-            <name>Transitive IPv4-Address-Specific Extended Community Sub-Type Ranges</name>
-            <thead>
-              <tr>
-                <th>SUB-TYPE VALUE RANGE</th>
-                <th>REGISTRATION PROCEDURES</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td align="left">0x00-0xBF</td>
-                <td align="left">First Come First Served</td>
-              </tr>
-              <tr>
-                <td align="left">0xC0-0xFF</td>
-                <td align="left">IETF Review</td>
-              </tr>
-            </tbody>
-          </table>
-          <t>
-            The IANA is requested to update the following references in the "Transitive IPv4-Address-Specific Extended Community Sub-Types"
-            registry <xref target="IANA-BGP-EC-TRANS-IPV4"/>:
-          </t>
-          <table>
-            <name>Transitive IPv4-Address-Specific Extended Community Sub-Types</name>
-            <thead>
-              <tr>
-                <th>SUB-TYPE VALUE</th>
-                <th>NAME</th>
-                <th>REFERENCE</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td align="left">0x02</td>
-                <td align="left">Route Target</td>
-                <td align="left">[this document]</td>
-              </tr>
-              <tr>
-                <td align="left">0x03</td>
-                <td align="left">Route Origin</td>
-                <td align="left">[this document]</td>
-              </tr>
-            </tbody>
-          </table>
-          <t>
-            The following table summarizes the ranges for the assignment of the "Non-Transitive IPv4-Address-Specific Extended Community
-            Sub-Types" registry <xref target="IANA-BGP-EC-NONTRANS-IPV4"/>:
-          </t>
-          <table>
-            <name>Non-Transitive IPv4-Address-Specific Extended Community Sub-Type Ranges</name>
-            <thead>
-              <tr>
-                <th>SUB-TYPE VALUE RANGE</th>
-                <th>REGISTRATION PROCEDURES</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td align="left">0x00-0xBF</td>
-                <td align="left">First Come First Served</td>
-              </tr>
-              <tr>
-                <td align="left">0xC0-0xFF</td>
-                <td align="left">IETF Review</td>
-              </tr>
-            </tbody>
-          </table>
-          <t>
-            All the communities in this class are of extended Types.
-            <xref target="RFC7153"/> includes further assignments of these registries.
-          </t>
-        </section>
-        <section title="Opaque Extended Community Sub-Types">
-          <t>
-            This document defines a class of extended communities called "Opaque Extended Community" for which the IANA is to create
-            and maintain two registries entitled "Transitive Opaque Extended Community Sub-Types" <xref target="IANA-BGP-EC-TRANS-OPAQUE"/>
-            and "Non-Transitive Opaque Extended Community Sub-Types" <xref target="IANA-BGP-EC-NONTRANS-OPAQUE"/>.
-          </t>
-          <t>
-            The following table summarizes the ranges for the assignment of the "Transitive Opaque Extended Community Sub-Types" registry
-            <xref target="IANA-BGP-EC-TRANS-OPAQUE"/>:
-          </t>
-          <table>
-            <name>Transitive Opaque Extended Community Sub-Type Ranges</name>
-            <thead>
-              <tr>
-                <th>SUB-TYPE VALUE RANGE</th>
-                <th>REGISTRATION PROCEDURES</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td align="left">0x00-0xBF</td>
-                <td align="left">First Come First Served</td>
-              </tr>
-              <tr>
-                <td align="left">0xC0-0xFF</td>
-                <td align="left">IETF Review</td>
-              </tr>
-            </tbody>
-          </table>
-          <t>
-            The following table summarizes the ranges for the assignment of the "Non-Transitive Opaque Extended Community Sub-Types"
-            registry <xref target="IANA-BGP-EC-NONTRANS-OPAQUE"/>:
-          </t>
-          <table>
-            <name>Non-Transitive Opaque Extended Community Sub-Type Ranges</name>
-            <thead>
-              <tr>
-                <th>SUB-TYPE VALUE RANGE</th>
-                <th>REGISTRATION PROCEDURES</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td align="left">0x00-0xBF</td>
-                <td align="left">First Come First Served</td>
-              </tr>
-              <tr>
-                <td align="left">0xC0-0xFF</td>
-                <td align="left">IETF Review</td>
-              </tr>
-            </tbody>
-          </table>
-          <t>
-            All the communities in this class are of extended Types.
-            <xref target="RFC7153"/> includes further assignments of these registries.
-          </t>
-        </section>
         <section title="Four-Octet AS-Specific Extended Community Sub-Types">
           <t>
             The IANA is requested to update the following references in the "Transitive Four-Octet AS-Specific Extended Community
@@ -956,19 +622,15 @@
     <references title="Normative References">
       <xi:include href="http://bib.ietf.org/public/rfc/bibxml/reference.RFC.1997.xml"/>
       <xi:include href="http://bib.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml"/>
-      <xi:include href="http://bib.ietf.org/public/rfc/bibxml/reference.RFC.3692.xml"/>
       <xi:include href="http://bib.ietf.org/public/rfc/bibxml/reference.RFC.4271.xml"/>
       <xi:include href="http://bib.ietf.org/public/rfc/bibxml/reference.RFC.5065.xml"/>
       <xi:include href="http://bib.ietf.org/public/rfc/bibxml/reference.RFC.5668.xml"/>
       <xi:include href="http://bib.ietf.org/public/rfc/bibxml/reference.RFC.5701.xml"/>
       <xi:include href="http://bib.ietf.org/public/rfc/bibxml/reference.RFC.6793.xml"/>
-      <xi:include href="http://bib.ietf.org/public/rfc/bibxml/reference.RFC.7120.xml"/>
       <xi:include href="http://bib.ietf.org/public/rfc/bibxml/reference.RFC.7153.xml"/>
       <xi:include href="http://bib.ietf.org/public/rfc/bibxml/reference.RFC.7454.xml"/>
       <xi:include href="http://bib.ietf.org/public/rfc/bibxml/reference.RFC.7606.xml"/>
-      <xi:include href="http://bib.ietf.org/public/rfc/bibxml/reference.RFC.8126.xml"/>
       <xi:include href="http://bib.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml"/>
-      <xi:include href="http://bib.ietf.org/public/rfc/bibxml/reference.RFC.9184.xml"/>
       <reference anchor="IANA-BGP-PATH-ATTRIBUTES" target="https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-2" derivedAnchor="IANA-BGP-PATH-ATTRIBUTES">
         <front>
           <title>BGP Path Attributes</title>

--- a/draft-ietf-idr-rfc4360-bis.xml
+++ b/draft-ietf-idr-rfc4360-bis.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-model href="rfc7991bis.rnc"?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" category="std" docName="draft-ietf-idr-rfc4360-bis-07" obsoletes="4360" updates="5701, 7153" submissionType="IETF" consensus="true" ipr="pre5378Trust200902" xml:lang="en">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" category="std" docName="draft-ietf-idr-rfc4360-bis-07" obsoletes="4360" updates="5701" submissionType="IETF" consensus="true" ipr="pre5378Trust200902" xml:lang="en">
   <front>
     <title abbrev="BGP Extended Communities Attribute">
       BGP Extended Communities Attribute


### PR DESCRIPTION
- Only keep "Table: BGP Transitive Extended Community Types", "Table: BGP Non-Transitive Extended Community Types"
- Since we've replaced all references to RFC 4360 with this document, old section 8.2.{123} are removed.
- Fix issue #60 